### PR TITLE
Migrate to v0.14 API

### DIFF
--- a/fluent-plugin-suppress.gemspec
+++ b/fluent-plugin-suppress.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = "0.0.7"
 
-  gem.add_runtime_dependency "fluentd", ">= 0.10.0"
+  gem.add_runtime_dependency "fluentd", [">= 0.14.8", "< 2"]
   gem.add_development_dependency "rake", ">= 0.9.2"
   gem.add_development_dependency "test-unit", ">= 3.0"
 end

--- a/fluent-plugin-suppress.gemspec
+++ b/fluent-plugin-suppress.gemspec
@@ -1,4 +1,3 @@
-# -*- encoding: utf-8 -*-
 # -*- mode:ruby -*-
 
 Gem::Specification.new do |gem|

--- a/lib/fluent/plugin/filter_suppress.rb
+++ b/lib/fluent/plugin/filter_suppress.rb
@@ -2,9 +2,9 @@ module Fluent
   class SuppressFilter < Filter
     Fluent::Plugin.register_filter('suppress', self)
 
-    config_param :attr_keys,     :string,  :default => nil
-    config_param :num,           :integer, :default => 3
-    config_param :interval,      :integer, :default => 300
+    config_param :attr_keys,     :string,  default: nil
+    config_param :num,           :integer, default: 3
+    config_param :interval,      :integer, default: 300
 
     def configure(conf)
       super

--- a/lib/fluent/plugin/filter_suppress.rb
+++ b/lib/fluent/plugin/filter_suppress.rb
@@ -49,5 +49,5 @@ module Fluent
       end
       return new_es
     end
-  end if defined?(Filter) # Support only >= v0.12
+  end
 end

--- a/lib/fluent/plugin/filter_suppress.rb
+++ b/lib/fluent/plugin/filter_suppress.rb
@@ -12,14 +12,6 @@ module Fluent
       @slots = {}
     end
 
-    def start
-      super
-    end
-
-    def shutdown
-      super
-    end
-
     def filter_stream(tag, es)
       new_es = MultiEventStream.new
       es.each do |time, record|

--- a/lib/fluent/plugin/filter_suppress.rb
+++ b/lib/fluent/plugin/filter_suppress.rb
@@ -1,5 +1,7 @@
-module Fluent
-  class SuppressFilter < Filter
+require 'fluent/plugin/filter'
+
+module Fluent::Plugin
+  class SuppressFilter < Fluent::Plugin::Filter
     Fluent::Plugin.register_filter('suppress', self)
 
     config_param :attr_keys,     :string,  default: nil
@@ -13,7 +15,7 @@ module Fluent
     end
 
     def filter_stream(tag, es)
-      new_es = MultiEventStream.new
+      new_es = Fluent::MultiEventStream.new
       es.each do |time, record|
         if @keys
           keys = @keys.map do |key|

--- a/lib/fluent/plugin/filter_suppress.rb
+++ b/lib/fluent/plugin/filter_suppress.rb
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 module Fluent
   class SuppressFilter < Filter
     Fluent::Plugin.register_filter('suppress', self)

--- a/lib/fluent/plugin/out_suppress.rb
+++ b/lib/fluent/plugin/out_suppress.rb
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 module Fluent
   class SuppressOutput < Output
     include Fluent::HandleTagNameMixin

--- a/lib/fluent/plugin/out_suppress.rb
+++ b/lib/fluent/plugin/out_suppress.rb
@@ -8,15 +8,6 @@ module Fluent
     config_param :num,           :integer, :default => 3
     config_param :interval,      :integer, :default => 300
 
-    unless method_defined?(:log)
-      define_method("log") { $log }
-    end
-
-    # Define `router` method of v0.12 to support v0.10 or earlier
-    unless method_defined?(:router)
-      define_method("router") { Fluent::Engine }
-    end
-
     def configure(conf)
       super
 

--- a/lib/fluent/plugin/out_suppress.rb
+++ b/lib/fluent/plugin/out_suppress.rb
@@ -4,9 +4,9 @@ module Fluent
 
     Fluent::Plugin.register_output('suppress', self)
 
-    config_param :attr_keys,     :string,  :default => nil
-    config_param :num,           :integer, :default => 3
-    config_param :interval,      :integer, :default => 300
+    config_param :attr_keys,     :string,  default: nil
+    config_param :num,           :integer, default: 3
+    config_param :interval,      :integer, default: 300
 
     def configure(conf)
       super

--- a/lib/fluent/plugin/out_suppress.rb
+++ b/lib/fluent/plugin/out_suppress.rb
@@ -30,14 +30,6 @@ module Fluent
       @slots = {}
     end
 
-    def start
-      super
-    end
-
-    def shutdown
-      super
-    end
-
     def emit(tag, es, chain)
       es.each do |time, record|
         if @keys

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,8 +1,8 @@
 require 'bundler/setup'
 require 'test/unit'
 
-$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
-$LOAD_PATH.unshift(File.dirname(__FILE__))
+$LOAD_PATH.unshift(File.join(__dir__, '..', 'lib'))
+$LOAD_PATH.unshift(__dir__)
 require 'fluent/test'
 unless ENV.has_key?('VERBOSE')
   nulllogger = Object.new

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,12 +1,4 @@
-require 'rubygems'
-require 'bundler'
-begin
-  Bundler.setup(:default, :development)
-rescue Bundler::BundlerError => e
-  $stderr.puts e.message
-  $stderr.puts "Run `bundle install` to install missing gems"
-  exit e.status_code
-end
+require 'bundler/setup'
 require 'test/unit'
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -4,15 +4,6 @@ require 'test/unit'
 $LOAD_PATH.unshift(File.join(__dir__, '..', 'lib'))
 $LOAD_PATH.unshift(__dir__)
 require 'fluent/test'
-unless ENV.has_key?('VERBOSE')
-  nulllogger = Object.new
-  nulllogger.instance_eval {|obj|
-    def method_missing(method, *args)
-      # pass
-    end
-  }
-  $log = nulllogger
-end
 
 require 'fluent/plugin/out_suppress'
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -4,8 +4,6 @@ require 'test/unit'
 $LOAD_PATH.unshift(File.join(__dir__, '..', 'lib'))
 $LOAD_PATH.unshift(__dir__)
 require 'fluent/test'
+require 'fluent/test/helpers'
 
-require 'fluent/plugin/out_suppress'
-
-class Test::Unit::TestCase
-end
+Test::Unit::TestCase.include(Fluent::Test::Helpers)

--- a/test/plugin/test_out_suppress.rb
+++ b/test/plugin/test_out_suppress.rb
@@ -1,4 +1,6 @@
 require 'helper'
+require 'fluent/test/driver/output'
+require 'fluent/plugin/out_suppress'
 
 class SuppressOutputTest < Test::Unit::TestCase
   def setup
@@ -25,81 +27,80 @@ class SuppressOutputTest < Test::Unit::TestCase
     add_tag_prefix sp.
   ]
 
-  def create_driver(conf = CONFIG, tag='test.info')
-    Fluent::Test::OutputTestDriver.new(Fluent::SuppressOutput, tag).configure(conf)
+  def create_driver(conf = CONFIG)
+    Fluent::Test::Driver::Output.new(Fluent::Plugin::SuppressOutput).configure(conf)
   end
 
   def test_emit
     d = create_driver
 
-    time = Time.parse("2012-11-22 11:22:33 UTC").to_i
-    d.run do
-      d.emit({"id" => 1, "host" => "web01", "message" => "error!!"}, time + 1)
-      d.emit({"id" => 2, "host" => "web01", "message" => "error!!"}, time + 2)
-      d.emit({"id" => 3, "host" => "web01", "message" => "error!!"}, time + 3)
-      d.emit({"id" => 4, "host" => "web01", "message" => "error!!"}, time + 4)
-      d.emit({"id" => 5, "host" => "app01", "message" => "error!!"}, time + 4)
-      d.emit({"id" => 6, "host" => "web01", "message" => "error!!"}, time + 12)
-      d.emit({"id" => 7, "host" => "web01", "message" => "error!!"}, time + 13)
-      d.emit({"id" => 8, "host" => "web01", "message" => "error!!"}, time + 14)
+    time = event_time("2012-11-22 11:22:33 UTC")
+    d.run(default_tag: "test.info") do
+      d.feed(time + 1,  {"id" => 1, "host" => "web01", "message" => "error!!"})
+      d.feed(time + 2,  {"id" => 2, "host" => "web01", "message" => "error!!"})
+      d.feed(time + 3,  {"id" => 3, "host" => "web01", "message" => "error!!"})
+      d.feed(time + 4,  {"id" => 4, "host" => "web01", "message" => "error!!"})
+      d.feed(time + 4,  {"id" => 5, "host" => "app01", "message" => "error!!"})
+      d.feed(time + 12, {"id" => 6, "host" => "web01", "message" => "error!!"})
+      d.feed(time + 13, {"id" => 7, "host" => "web01", "message" => "error!!"})
+      d.feed(time + 14, {"id" => 8, "host" => "web01", "message" => "error!!"})
     end
 
-    emits = d.emits
-    assert_equal 5, emits.length
-    assert_equal ["sp.test.info", time + 1,  {"id"=>1, "host"=>"web01", "message"=>"error!!"}], emits[0]
-    assert_equal ["sp.test.info", time + 2,  {"id"=>2, "host"=>"web01", "message"=>"error!!"}], emits[1]
-    assert_equal ["sp.test.info", time + 4,  {"id"=>5, "host"=>"app01", "message"=>"error!!"}], emits[2]
-    assert_equal ["sp.test.info", time + 12, {"id"=>6, "host"=>"web01", "message"=>"error!!"}], emits[3]
-    assert_equal ["sp.test.info", time + 13, {"id"=>7, "host"=>"web01", "message"=>"error!!"}], emits[4]
+    events = d.events
+    assert_equal 5, events.length
+    assert_equal ["sp.test.info", time + 1,  {"id"=>1, "host"=>"web01", "message"=>"error!!"}], events[0]
+    assert_equal ["sp.test.info", time + 2,  {"id"=>2, "host"=>"web01", "message"=>"error!!"}], events[1]
+    assert_equal ["sp.test.info", time + 4,  {"id"=>5, "host"=>"app01", "message"=>"error!!"}], events[2]
+    assert_equal ["sp.test.info", time + 12, {"id"=>6, "host"=>"web01", "message"=>"error!!"}], events[3]
+    assert_equal ["sp.test.info", time + 13, {"id"=>7, "host"=>"web01", "message"=>"error!!"}], events[4]
 
   end
 
   def test_emit_wtih_nested_key
     d = create_driver(CONFIG_WITH_NESTED_KEY)
 
-    time = Time.parse("2012-11-22 11:22:33 UTC").to_i
-    d.run do
-      d.emit({"id" => 1, "data" => {"host" => "web01", "message" => "error!!"}}, time + 1)
-      d.emit({"id" => 2, "data" => {"host" => "web01", "message" => "error!!"}}, time + 2)
-      d.emit({"id" => 3, "data" => {"host" => "web01", "message" => "error!!"}}, time + 3)
-      d.emit({"id" => 4, "data" => {"host" => "web01", "message" => "error!!"}}, time + 4)
-      d.emit({"id" => 5, "data" => {"host" => "app01", "message" => "error!!"}}, time + 4)
-      d.emit({"id" => 6, "data" => {"host" => "web01", "message" => "error!!"}}, time + 12)
-      d.emit({"id" => 7, "data" => {"host" => "web01", "message" => "error!!"}}, time + 13)
-      d.emit({"id" => 8, "data" => {"host" => "web01", "message" => "error!!"}}, time + 14)
+    time = event_time("2012-11-22 11:22:33 UTC")
+    d.run(default_tag: "test.info") do
+      d.feed(time + 1,  {"id" => 1, "data" => {"host" => "web01", "message" => "error!!"}})
+      d.feed(time + 2,  {"id" => 2, "data" => {"host" => "web01", "message" => "error!!"}})
+      d.feed(time + 3,  {"id" => 3, "data" => {"host" => "web01", "message" => "error!!"}})
+      d.feed(time + 4,  {"id" => 4, "data" => {"host" => "web01", "message" => "error!!"}})
+      d.feed(time + 4,  {"id" => 5, "data" => {"host" => "app01", "message" => "error!!"}})
+      d.feed(time + 12, {"id" => 6, "data" => {"host" => "web01", "message" => "error!!"}})
+      d.feed(time + 13, {"id" => 7, "data" => {"host" => "web01", "message" => "error!!"}})
+      d.feed(time + 14, {"id" => 8, "data" => {"host" => "web01", "message" => "error!!"}})
     end
 
-    emits = d.emits
-    assert_equal 5, emits.length
-    assert_equal ["sp.test.info", time + 1,  {"id"=>1, "data" => {"host"=>"web01", "message"=>"error!!"}}], emits[0]
-    assert_equal ["sp.test.info", time + 2,  {"id"=>2, "data" => {"host"=>"web01", "message"=>"error!!"}}], emits[1]
-    assert_equal ["sp.test.info", time + 4,  {"id"=>5, "data" => {"host"=>"app01", "message"=>"error!!"}}], emits[2]
-    assert_equal ["sp.test.info", time + 12, {"id"=>6, "data" => {"host"=>"web01", "message"=>"error!!"}}], emits[3]
-    assert_equal ["sp.test.info", time + 13, {"id"=>7, "data" => {"host"=>"web01", "message"=>"error!!"}}], emits[4]
+    events = d.events
+    assert_equal 5, events.length
+    assert_equal ["sp.test.info", time + 1,  {"id"=>1, "data" => {"host"=>"web01", "message"=>"error!!"}}], events[0]
+    assert_equal ["sp.test.info", time + 2,  {"id"=>2, "data" => {"host"=>"web01", "message"=>"error!!"}}], events[1]
+    assert_equal ["sp.test.info", time + 4,  {"id"=>5, "data" => {"host"=>"app01", "message"=>"error!!"}}], events[2]
+    assert_equal ["sp.test.info", time + 12, {"id"=>6, "data" => {"host"=>"web01", "message"=>"error!!"}}], events[3]
+    assert_equal ["sp.test.info", time + 13, {"id"=>7, "data" => {"host"=>"web01", "message"=>"error!!"}}], events[4]
 
   end
 
   def test_emit_tagonly
     d = create_driver(CONFIG_TAG_ONLY)
 
-    time = Time.parse("2012-11-22 11:22:33 UTC").to_i
-    d.run do
-      d.emit({"id" => 1, "host" => "web01", "message" => "1 error!!"}, time + 1)
-      d.emit({"id" => 2, "host" => "web02", "message" => "2 error!!"}, time + 2)
-      d.emit({"id" => 3, "host" => "web03", "message" => "3 error!!"}, time + 3)
-      d.emit({"id" => 4, "host" => "web04", "message" => "4 error!!"}, time + 4)
-      d.emit({"id" => 5, "host" => "app05", "message" => "5 error!!"}, time + 4)
-      d.emit({"id" => 6, "host" => "web06", "message" => "6 error!!"}, time + 12)
-      d.emit({"id" => 7, "host" => "web07", "message" => "7 error!!"}, time + 13)
-      d.emit({"id" => 8, "host" => "web08", "message" => "8 error!!"}, time + 14)
+    time = event_time("2012-11-22 11:22:33 UTC")
+    d.run(default_tag: "test.info") do
+      d.feed(time + 1,  {"id" => 1, "host" => "web01", "message" => "1 error!!"})
+      d.feed(time + 2,  {"id" => 2, "host" => "web02", "message" => "2 error!!"})
+      d.feed(time + 3,  {"id" => 3, "host" => "web03", "message" => "3 error!!"})
+      d.feed(time + 4,  {"id" => 4, "host" => "web04", "message" => "4 error!!"})
+      d.feed(time + 4,  {"id" => 5, "host" => "app05", "message" => "5 error!!"})
+      d.feed(time + 12, {"id" => 6, "host" => "web06", "message" => "6 error!!"})
+      d.feed(time + 13, {"id" => 7, "host" => "web07", "message" => "7 error!!"})
+      d.feed(time + 14, {"id" => 8, "host" => "web08", "message" => "8 error!!"})
     end
 
-    emits = d.emits
-    assert_equal 4, emits.length
-    assert_equal ["sp.test.info", time + 1,  {"id"=>1, "host"=>"web01", "message"=>"1 error!!"}], emits[0]
-    assert_equal ["sp.test.info", time + 2,  {"id"=>2, "host"=>"web02", "message"=>"2 error!!"}], emits[1]
-    assert_equal ["sp.test.info", time + 12, {"id"=>6, "host"=>"web06", "message"=>"6 error!!"}], emits[2]
-    assert_equal ["sp.test.info", time + 13, {"id"=>7, "host"=>"web07", "message"=>"7 error!!"}], emits[3]
+    events = d.events
+    assert_equal 4, events.length
+    assert_equal ["sp.test.info", time + 1,  {"id"=>1, "host"=>"web01", "message"=>"1 error!!"}], events[0]
+    assert_equal ["sp.test.info", time + 2,  {"id"=>2, "host"=>"web02", "message"=>"2 error!!"}], events[1]
+    assert_equal ["sp.test.info", time + 12, {"id"=>6, "host"=>"web06", "message"=>"6 error!!"}], events[2]
+    assert_equal ["sp.test.info", time + 13, {"id"=>7, "host"=>"web07", "message"=>"7 error!!"}], events[3]
   end
-
 end


### PR DESCRIPTION
This PR drops v0.12 or earlier support.

See http://docs.fluentd.org/v0.14/articles/plugin-update-from-v12