### PR TITLE
Add `max_slot_num` param to limit memory usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,14 @@ fluentd.conf
   @type          suppress
   interval       10
   num            2
+  max_slot_num   100000
   attr_keys      host,message
   add_tag_prefix sp.
 </match>
 ```
 
 In `interval` sec, `num` messages which grouped by `attr_keys` value, add tag prefix "`sp.`" and pass to follow process. Other messages will be removed.
+`max_slot_num` put an upper limit on the length of the internal variable which contains message occurences.
 
 Input messages:
 

--- a/lib/fluent/plugin/out_suppress.rb
+++ b/lib/fluent/plugin/out_suppress.rb
@@ -10,6 +10,7 @@ module Fluent::Plugin
 
     config_param :attr_keys,     :string,  default: nil
     config_param :num,           :integer, default: 3
+    config_param :max_slot_num,  :integer, default: 100000
     config_param :interval,      :integer, default: 300
 
     def configure(conf)
@@ -50,6 +51,13 @@ module Fluent::Plugin
         if slot.length >= @num
           log.debug "suppressed record: #{record.to_json}"
           next
+        end
+
+        if @slots.length > @max_slot_num
+          (evict_key, evict_slot) = @slots.shift
+          if evict_slot.last && (evict_slot.last > expired)
+            log.warn "@slots length exceeded @max_slot_num: #{@max_slot_num}. Evicted slot for the key: #{evict_key}"
+          end
         end
 
         slot.push(time.to_f)

--- a/test/plugin/test_filter_suppress.rb
+++ b/test/plugin/test_filter_suppress.rb
@@ -26,6 +26,13 @@ class SuppressFilterTest < Test::Unit::TestCase
     num      2
   ]
 
+  CONFIG_MAX_SLOT_NUM = %[
+    interval       10
+    num            2
+    max_slot_num   3
+    attr_keys      host, message
+  ]
+
   def create_driver(conf = CONFIG)
     Fluent::Test::Driver::Filter.new(Fluent::Plugin::SuppressFilter).configure(conf)
   end
@@ -108,5 +115,31 @@ class SuppressFilterTest < Test::Unit::TestCase
     assert_equal({"id"=>2, "host"=>"web02", "message"=>"2 error!!"}, records[1])
     assert_equal({"id"=>6, "host"=>"web06", "message"=>"6 error!!"}, records[2])
     assert_equal({"id"=>7, "host"=>"web07", "message"=>"7 error!!"}, records[3])
+  end
+
+  def test_emit_max_slot_num
+    d = create_driver(CONFIG_MAX_SLOT_NUM)
+    es = Fluent::MultiEventStream.new
+
+    time = event_time("2012-11-22 11:22:33 UTC")
+    es.add(time + 1,  {"id" => 1, "host" => "web01", "message" => "1 error!!"})
+    es.add(time + 2,  {"id" => 2, "host" => "web02", "message" => "2 error!!"})
+    es.add(time + 3,  {"id" => 3, "host" => "web03", "message" => "3 error!!"})
+    es.add(time + 4,  {"id" => 4, "host" => "web01", "message" => "1 error!!"})
+    es.add(time + 5,  {"id" => 5, "host" => "web04", "message" => "4 error!!"})
+    es.add(time + 6,  {"id" => 6, "host" => "web01", "message" => "1 error!!"})
+
+    d.run(default_tag: "test.info") do
+      d.feed(es)
+    end
+    records = d.filtered_records
+
+    assert_equal 6, records.length
+    assert_equal({"id"=>1, "host"=>"web01", "message"=>"1 error!!"}, records[0])
+    assert_equal({"id"=>2, "host"=>"web02", "message"=>"2 error!!"}, records[1])
+    assert_equal({"id"=>3, "host"=>"web03", "message"=>"3 error!!"}, records[2])
+    assert_equal({"id"=>4, "host"=>"web01", "message"=>"1 error!!"}, records[3])
+    assert_equal({"id"=>5, "host"=>"web04", "message"=>"4 error!!"}, records[4])
+    assert_equal({"id"=>6, "host"=>"web01", "message"=>"1 error!!"}, records[5])
   end
 end

--- a/test/plugin/test_out_suppress.rb
+++ b/test/plugin/test_out_suppress.rb
@@ -27,6 +27,14 @@ class SuppressOutputTest < Test::Unit::TestCase
     add_tag_prefix sp.
   ]
 
+  CONFIG_MAX_SLOT_NUM = %[
+    interval       10
+    num            2
+    max_slot_num   3
+    attr_keys      host, message
+    add_tag_prefix sp.
+  ]
+
   def create_driver(conf = CONFIG)
     Fluent::Test::Driver::Output.new(Fluent::Plugin::SuppressOutput).configure(conf)
   end
@@ -102,5 +110,28 @@ class SuppressOutputTest < Test::Unit::TestCase
     assert_equal ["sp.test.info", time + 2,  {"id"=>2, "host"=>"web02", "message"=>"2 error!!"}], events[1]
     assert_equal ["sp.test.info", time + 12, {"id"=>6, "host"=>"web06", "message"=>"6 error!!"}], events[2]
     assert_equal ["sp.test.info", time + 13, {"id"=>7, "host"=>"web07", "message"=>"7 error!!"}], events[3]
+  end
+
+  def test_emit_max_slot_num
+    d = create_driver(CONFIG_MAX_SLOT_NUM)
+
+    time = event_time("2012-11-22 11:22:33 UTC")
+    d.run(default_tag: "test.info") do
+      d.feed(time + 1,  {"id" => 1, "host" => "web01", "message" => "1 error!!"})
+      d.feed(time + 2,  {"id" => 2, "host" => "web02", "message" => "2 error!!"})
+      d.feed(time + 3,  {"id" => 3, "host" => "web03", "message" => "3 error!!"})
+      d.feed(time + 4,  {"id" => 4, "host" => "web01", "message" => "1 error!!"})
+      d.feed(time + 5,  {"id" => 5, "host" => "web04", "message" => "4 error!!"})
+      d.feed(time + 6,  {"id" => 6, "host" => "web01", "message" => "1 error!!"})
+    end
+
+    events = d.events
+    assert_equal 6, events.length
+    assert_equal ["sp.test.info", time + 1,  {"id"=>1, "host"=>"web01", "message"=>"1 error!!"}], events[0]
+    assert_equal ["sp.test.info", time + 2,  {"id"=>2, "host"=>"web02", "message"=>"2 error!!"}], events[1]
+    assert_equal ["sp.test.info", time + 3,  {"id"=>3, "host"=>"web03", "message"=>"3 error!!"}], events[2]
+    assert_equal ["sp.test.info", time + 4,  {"id"=>4, "host"=>"web01", "message"=>"1 error!!"}], events[3]
+    assert_equal ["sp.test.info", time + 5,  {"id"=>5, "host"=>"web04", "message"=>"4 error!!"}], events[4]
+    assert_equal ["sp.test.info", time + 6,  {"id"=>6, "host"=>"web01", "message"=>"1 error!!"}], events[5]
   end
 end


### PR DESCRIPTION
Currently, the `@slots` length can grow without any limitation when cardinarity of `attr_key` is large enough.

Introduces `max_slot_num` param to put an upper limit on the `@slots` length to control memory usage.