### PR TITLE
Use block to output logs due to reduce memory usage

### DIFF
--- a/lib/fluent/plugin/filter_suppress.rb
+++ b/lib/fluent/plugin/filter_suppress.rb
@@ -35,14 +35,14 @@ module Fluent::Plugin
         end
 
         if slot.length >= @num
-          log.debug "suppressed record: #{record.to_json}"
+          log.debug { "suppressed record: #{record.to_json}" }
           next
         end
 
         if @slots.length > @max_slot_num
           (evict_key, evict_slot) = @slots.shift
           if evict_slot.last && (evict_slot.last > expired)
-            log.warn "@slots length exceeded @max_slot_num: #{@max_slot_num}. Evicted slot for the key: #{evict_key}"
+            log.warn { "@slots length exceeded @max_slot_num: #{@max_slot_num}. Evicted slot for the key: #{evict_key}" }
           end
         end
 

--- a/lib/fluent/plugin/out_suppress.rb
+++ b/lib/fluent/plugin/out_suppress.rb
@@ -49,14 +49,14 @@ module Fluent::Plugin
         end
 
         if slot.length >= @num
-          log.debug "suppressed record: #{record.to_json}"
+          log.debug { "suppressed record: #{record.to_json}" }
           next
         end
 
         if @slots.length > @max_slot_num
           (evict_key, evict_slot) = @slots.shift
           if evict_slot.last && (evict_slot.last > expired)
-            log.warn "@slots length exceeded @max_slot_num: #{@max_slot_num}. Evicted slot for the key: #{evict_key}"
+            log.warn { "@slots length exceeded @max_slot_num: #{@max_slot_num}. Evicted slot for the key: #{evict_key}" }
           end
         end
 
@@ -66,7 +66,7 @@ module Fluent::Plugin
         if @labelled || tag != _tag
           router.emit(_tag, time, record)
         else
-          log.warn "Drop record #{record} tag '#{tag}' was not replaced. Can't emit record, cause infinity looping. Set remove_tag_prefix, remove_tag_suffix, add_tag_prefix or add_tag_suffix correctly."
+          log.warn { "Drop record #{record} tag '#{tag}' was not replaced. Can't emit record, cause infinity looping. Set remove_tag_prefix, remove_tag_suffix, add_tag_prefix or add_tag_suffix correctly." }
         end
       end
     end


### PR DESCRIPTION
The many long duplicated logs seem to use a lot of memory at `record.to_json` in `log.debug`.
https://github.com/fujiwara/fluent-plugin-suppress/blob/d2271216fcc5355a5e1f80d2586274d00124110e/lib/fluent/plugin/filter_suppress.rb#L38

`log.debug "log message"` does not output the message with `info` log level. 
However, the message have been evaluated.

If passes the block instead, `log.debug` will evaluate the block only when output the message.

Related to https://github.com/fluent/fluentd/issues/4808

## Reproduce
### Fluentd configuration
```
<source>
  @type tail
  path "#{File.expand_path '~/tmp/access*.log'}"
  pos_file "#{File.expand_path '~/tmp/fluentd/access.log.pos'}"
  tag log
  <parse>
    @type none
  </parse>
</source>

<filter log.**>
    @type suppress
    log_suppress_interval 10
    num 1
    max_slot_num 10
    attr_keys short_message
</filter>

<match **>
  @type stdout
</match>
```

### Log generate script
```ruby
require "json"

path = File.expand_path("~/tmp/access.log")
File.open(path, "w") do |f|
  log = { "message": "a" * 500_000 }.to_json
  loop do
    f.puts log
    sleep 0.0001
  end
end
```

### Result
<img src="https://github.com/user-attachments/assets/d5c50d66-1519-4a1d-b83d-23107ea5ea35" width="500" />


